### PR TITLE
Fix README event block

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ Could be managed within moveCharacter().
 event CharacterMoved(uint256 x, uint256 y);
 event CollisionDetected(uint256 obstacleId);
 event TileRevealed(uint256 x, uint256 y);
----
 ```
 Off-chain indexers or front-ends can subscribe to these events to visualize state changes in real time.
 ## 6. Technical Considerations


### PR DESCRIPTION
## Summary
- remove extraneous separator line from the event emission code block

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68407fc73238832cab096eacdbda6d4e