### PR TITLE
Fix tokenURI bullet formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@
 
 5. **On-Chain SVG Update**  
    - The `HitboxNFT` references `HitboxGame` state to build an updated 32×32 pixel window around the character.  
-   - The NFT’s `tokenURI()` returns a fresh **data:` SVG** for marketplaces.
+   - The NFT’s `tokenURI()` returns a fresh `data:`SVG for marketplaces.
 
 6. **Observing the Game**  
    - Anyone can watch the state changes or see the NFT updates.  


### PR DESCRIPTION
## Summary
- fix the `tokenURI()` bullet in README so only the `data:` prefix is in code format

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68407fc0dd7c832c99e3ea3df847b8f9