### PR TITLE
Add Hardhat environment and deployment script

### DIFF
--- a/contracts/HitboxGame.sol
+++ b/contracts/HitboxGame.sol
@@ -1,1 +1,6 @@
-// Placeholder for HitboxGame.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract HitboxGame {
+    // TODO: Implement game logic
+}

--- a/contracts/HitboxNFT.sol
+++ b/contracts/HitboxNFT.sol
@@ -1,1 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
 
+contract HitboxNFT {
+    // TODO: Implement NFT logic
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,5 @@
+require("@nomiclabs/hardhat-ethers");
+
+module.exports = {
+  solidity: "0.8.20",
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "hitbox",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "compile": "hardhat compile",
+    "test": "hardhat test",
+    "deploy": "hardhat run scripts/deploy.js"
+  },
+  "devDependencies": {
+    "hardhat": "^2.20.0",
+    "@nomiclabs/hardhat-ethers": "^2.2.2",
+    "ethers": "^5.7.2",
+    "chai": "^4.3.7",
+    "mocha": "^10.2.0"
+  }
+}

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,1 +1,17 @@
+const hre = require("hardhat");
 
+async function main() {
+  const [deployer] = await hre.ethers.getSigners();
+  console.log("Deploying contracts with account:", deployer.address);
+
+  const HitboxGame = await hre.ethers.getContractFactory("HitboxGame");
+  const game = await HitboxGame.deploy();
+  await game.deployed();
+
+  console.log("HitboxGame deployed to:", game.address);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- set up `package.json` with Hardhat and Ethers
- create minimal Hardhat config
- add placeholder contracts so compilation succeeds
- implement a simple deployment script

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run compile` *(fails: hardhat not found)*
- `npm test` *(fails: hardhat not found)*
- `npm run deploy` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407f56b06c832c8fde2b0a505629a7