### PR TITLE
Add Hardhat test skeletons

### DIFF
--- a/contracts/HitboxGame.sol
+++ b/contracts/HitboxGame.sol
@@ -1,1 +1,74 @@
-// Placeholder for HitboxGame.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+/**
+ * @title HitboxGame
+ * @dev Simplified game contract used for Hardhat tests.
+ *      Maintains character position, basic collision logic,
+ *      and tile reveal proofs.
+ */
+contract HitboxGame {
+    struct Position {
+        uint256 x;
+        uint256 y;
+    }
+
+    Position public start = Position(0, 0);
+    Position public character = Position(0, 0);
+    Position public obstacle = Position(1, 0);
+
+    mapping(address => bool) public authorized;
+    mapping(uint256 => mapping(uint256 => bool)) public revealed;
+
+    // Fake world root: keccak256("validTile")
+    bytes32 public constant WORLD_ROOT = keccak256("validTile");
+
+    event CharacterMoved(uint256 x, uint256 y);
+    event CollisionReset(uint256 x, uint256 y);
+    event TileRevealed(uint256 x, uint256 y);
+
+    /**
+     * @notice Authorize an address to control the character.
+     */
+    function authorize(address addr) external {
+        authorized[addr] = true;
+    }
+
+    /**
+     * @notice Move the character in a direction.
+     * @param direction 0=up,1=down,2=left,3=right
+     * @param tileData data for tile reveal proof
+     */
+    function move(uint8 direction, bytes calldata tileData) external {
+        require(authorized[msg.sender], "Not authorized");
+
+        if (direction == 0) {
+            character.y += 1;
+        } else if (direction == 1) {
+            if (character.y > 0) character.y -= 1;
+        } else if (direction == 2) {
+            if (character.x > 0) character.x -= 1;
+        } else if (direction == 3) {
+            character.x += 1;
+        } else {
+            revert("Invalid direction");
+        }
+
+        // Check collision
+        if (character.x == obstacle.x && character.y == obstacle.y) {
+            character = start;
+            emit CollisionReset(character.x, character.y);
+        }
+
+        // Verify tile data
+        require(keccak256(tileData) == WORLD_ROOT, "Invalid proof");
+        revealed[character.x][character.y] = true;
+        emit TileRevealed(character.x, character.y);
+
+        emit CharacterMoved(character.x, character.y);
+    }
+
+    function getPosition() external view returns (uint256, uint256) {
+        return (character.x, character.y);
+    }
+}

--- a/contracts/HitboxNFT.sol
+++ b/contracts/HitboxNFT.sol
@@ -1,1 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
 
+import "./HitboxGame.sol";
+
+/**
+ * @title HitboxNFT
+ * @dev Minimal NFT contract for testing tokenURI logic.
+ */
+contract HitboxNFT {
+    HitboxGame public game;
+    mapping(uint256 => address) public ownerOf;
+    string public baseURI;
+
+    constructor(address game_, string memory baseURI_) {
+        game = HitboxGame(game_);
+        baseURI = baseURI_;
+    }
+
+    function mint(address to, uint256 tokenId) external {
+        ownerOf[tokenId] = to;
+    }
+
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
+        require(ownerOf[tokenId] != address(0), "NONEXISTENT");
+        (uint256 x, uint256 y) = game.getPosition();
+        return string(
+            abi.encodePacked(
+                baseURI,
+                "/",
+                _toString(tokenId),
+                "?x=",
+                _toString(x),
+                "&y=",
+                _toString(y)
+            )
+        );
+    }
+
+    function _toString(uint256 value) internal pure returns (string memory) {
+        if (value == 0) {
+            return "0";
+        }
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        return string(buffer);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,5 @@
+require("@nomicfoundation/hardhat-chai-matchers");
+
+module.exports = {
+  solidity: "0.8.23",
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hitbox",
+  "version": "1.0.0",
+  "devDependencies": {
+    "hardhat": "^2.20.2",
+    "@nomicfoundation/hardhat-chai-matchers": "^1.0.0",
+    "chai": "^4.3.6",
+    "ethereum-waffle": "^3.4.0"
+  },
+  "scripts": {
+    "test": "hardhat test"
+  }
+}

--- a/test/HitboxGame.test.js
+++ b/test/HitboxGame.test.js
@@ -1,1 +1,46 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
 
+describe("HitboxGame", function () {
+  let game;
+  let owner, user;
+  const validTile = ethers.utils.toUtf8Bytes("validTile");
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+    const Game = await ethers.getContractFactory("HitboxGame");
+    game = await Game.deploy();
+    await game.deployed();
+  });
+
+  it("allows authorized movement and tile reveal", async function () {
+    await game.authorize(owner.address);
+    await expect(game.move(3, validTile))
+      .to.emit(game, "CharacterMoved")
+      .withArgs(1, 0);
+    const pos = await game.getPosition();
+    expect(pos[0]).to.equal(1);
+    expect(await game.revealed(1, 0)).to.equal(true);
+  });
+
+  it("reverts unauthorized moves", async function () {
+    await expect(game.connect(user).move(3, validTile)).to.be.revertedWith(
+      "Not authorized"
+    );
+  });
+
+  it("resets position on collision", async function () {
+    await game.authorize(owner.address);
+    // First move right into obstacle at (1,0)
+    await game.move(3, validTile);
+    const pos = await game.getPosition();
+    expect(pos[0]).to.equal(0);
+    expect(pos[1]).to.equal(0);
+  });
+
+  it("reverts on invalid proof", async function () {
+    await game.authorize(owner.address);
+    const bad = ethers.utils.toUtf8Bytes("badTile");
+    await expect(game.move(3, bad)).to.be.revertedWith("Invalid proof");
+  });
+});

--- a/test/HitboxNFT.test.js
+++ b/test/HitboxNFT.test.js
@@ -1,1 +1,29 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
 
+describe("HitboxNFT", function () {
+  let game, nft, owner;
+  const validTile = ethers.utils.toUtf8Bytes("validTile");
+
+  beforeEach(async function () {
+    [owner] = await ethers.getSigners();
+    const Game = await ethers.getContractFactory("HitboxGame");
+    game = await Game.deploy();
+    await game.deployed();
+
+    const NFT = await ethers.getContractFactory("HitboxNFT");
+    nft = await NFT.deploy(game.address, "ipfs://base");
+    await nft.deployed();
+
+    await game.authorize(owner.address);
+    await nft.mint(owner.address, 1);
+  });
+
+  it("returns dynamic tokenURI", async function () {
+    await game.move(3, validTile); // move right to (1,0) but will reset
+    const uri = await nft.tokenURI(1);
+    expect(uri).to.contain("ipfs://base/1");
+    expect(uri).to.contain("x=0");
+    expect(uri).to.contain("y=0");
+  });
+});


### PR DESCRIPTION
## Summary
- add minimal contracts for HitboxGame and HitboxNFT
- set up Hardhat with chai matchers
- provide unit tests for game movement, collisions, invalid proofs, and tokenURI

## Testing
- `npx hardhat test` *(fails: 403 Forbidden fetching hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68407f3e5318832cabd67e18cd55f085