### PR TITLE
Add Hardhat configuration and deployment scripts

### DIFF
--- a/contracts/HitboxGame.sol
+++ b/contracts/HitboxGame.sol
@@ -1,1 +1,32 @@
-// Placeholder for HitboxGame.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract HitboxGame {
+    struct Position {
+        uint256 x;
+        uint256 y;
+    }
+
+    Position public character;
+
+    mapping(bytes32 => bool) public revealed;
+
+    event CharacterMoved(uint256 x, uint256 y);
+    event TileRevealed(uint256 x, uint256 y);
+
+    function move(int256 dx, int256 dy) external {
+        int256 nx = int256(character.x) + dx;
+        int256 ny = int256(character.y) + dy;
+        if (nx < 0) nx = 0;
+        if (ny < 0) ny = 0;
+        character.x = uint256(nx);
+        character.y = uint256(ny);
+        emit CharacterMoved(character.x, character.y);
+    }
+
+    function reveal(uint256 x, uint256 y) external {
+        bytes32 key = keccak256(abi.encodePacked(x, y));
+        revealed[key] = true;
+        emit TileRevealed(x, y);
+    }
+}

--- a/contracts/HitboxNFT.sol
+++ b/contracts/HitboxNFT.sol
@@ -1,1 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
 
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract HitboxNFT is ERC721 {
+    address public game;
+    uint256 public nextTokenId = 1;
+
+    constructor(address _game) ERC721("HitboxNFT", "HIT") {
+        game = _game;
+    }
+
+    function mint(address to) external {
+        _safeMint(to, nextTokenId);
+        nextTokenId++;
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,12 @@
+require('@nomiclabs/hardhat-ethers');
+require('@nomiclabs/hardhat-waffle');
+
+/** @type import('hardhat/config').HardhatUserConfig */
+module.exports = {
+  solidity: '0.8.20',
+  networks: {
+    localhost: {
+      url: 'http://127.0.0.1:8545'
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "hitbox",
+  "version": "1.0.0",
+  "description": "Hardhat project for Hitbox",
+  "scripts": {
+    "test": "npx hardhat test",
+    "compile": "npx hardhat compile",
+    "deploy": "npx hardhat run scripts/deploy.js --network localhost",
+    "interact": "node scripts/interact.js"
+  },
+  "devDependencies": {
+    "@nomiclabs/hardhat-ethers": "^2.2.0",
+    "@nomiclabs/hardhat-waffle": "^2.0.3",
+    "@openzeppelin/contracts": "^5.0.0",
+    "chai": "^4.3.7",
+    "ethereum-waffle": "^3.4.4",
+    "ethers": "^6.6.2",
+    "hardhat": "^2.21.0"
+  }
+}

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,1 +1,20 @@
+const hre = require('hardhat');
 
+async function main() {
+  await hre.run('compile');
+
+  const HitboxGame = await hre.ethers.getContractFactory('HitboxGame');
+  const game = await HitboxGame.deploy();
+  await game.deployed();
+  console.log('HitboxGame deployed to:', game.address);
+
+  const HitboxNFT = await hre.ethers.getContractFactory('HitboxNFT');
+  const nft = await HitboxNFT.deploy(game.address);
+  await nft.deployed();
+  console.log('HitboxNFT deployed to:', nft.address);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/interact.js
+++ b/scripts/interact.js
@@ -1,1 +1,34 @@
-// Placeholder Script(s) to interact with the deployed contracts
+const hre = require('hardhat');
+
+async function main() {
+  const [signer] = await hre.ethers.getSigners();
+
+  const gameAddress = process.env.GAME_ADDRESS || process.argv[2];
+  const nftAddress = process.env.NFT_ADDRESS || process.argv[3];
+
+  if (!gameAddress || !nftAddress) {
+    console.error('Usage: GAME_ADDRESS=<addr> NFT_ADDRESS=<addr> npx hardhat run scripts/interact.js --network localhost');
+    return;
+  }
+
+  const game = await hre.ethers.getContractAt('HitboxGame', gameAddress, signer);
+  const nft = await hre.ethers.getContractAt('HitboxNFT', nftAddress, signer);
+
+  console.log('Moving character right by 1...');
+  await (await game.move(1, 0)).wait();
+
+  console.log('Revealing tile at (1,0)...');
+  await (await game.reveal(1, 0)).wait();
+
+  const position = await game.character();
+  console.log('Character position:', position.x.toString(), position.y.toString());
+
+  console.log('Minting NFT to signer...');
+  await (await nft.mint(signer.address)).wait();
+  console.log('NFT minted with tokenId 1');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- set up Hardhat with `hardhat.config.js` and `package.json`
- implement basic `HitboxGame` and `HitboxNFT` contracts
- add deployment script
- add interaction script to move character and reveal tiles

## Testing
- `npx hardhat compile` *(fails: 403 Forbidden)*
- `npx hardhat test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68407f367960832c8f0f4dbfbe6dba67