### PR TITLE
Fix README event emission block

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ Could be managed within moveCharacter().
 event CharacterMoved(uint256 x, uint256 y);
 event CollisionDetected(uint256 obstacleId);
 event TileRevealed(uint256 x, uint256 y);
----
 ```
 Off-chain indexers or front-ends can subscribe to these events to visualize state changes in real time.
 ## 6. Technical Considerations


### PR DESCRIPTION
## Summary
- remove stray horizontal rule from event emission example

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407d79b48c832cbecb04ad2de5c0e2