### PR TITLE
Add minimal game and NFT contracts

### DIFF
--- a/contracts/HitboxGame.sol
+++ b/contracts/HitboxGame.sol
@@ -1,1 +1,108 @@
-// Placeholder for HitboxGame.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+
+/**
+ * @title HitboxGame
+ * @notice Minimal game contract storing a Merkle root of the hidden world.
+ *         Handles movement, obstacle collisions and tile reveal proofs.
+ */
+contract HitboxGame {
+    bytes32 public worldRoot;
+
+    struct Position {
+        uint256 x;
+        uint256 y;
+    }
+
+    Position public characterPosition;
+
+    struct Obstacle {
+        Position pos;
+    }
+
+    mapping(uint256 => Obstacle) public obstacles;
+
+    // Track revealed tiles using a hash of coordinates
+    mapping(bytes32 => bool) public revealedTiles;
+
+    event CharacterMoved(uint256 x, uint256 y);
+    event CollisionDetected(uint256 obstacleId);
+    event TileRevealed(uint256 x, uint256 y);
+
+    constructor(bytes32 _worldRoot, uint256 startX, uint256 startY) {
+        worldRoot = _worldRoot;
+        characterPosition = Position(startX, startY);
+    }
+
+    enum Direction { Left, Right, Up, Down }
+
+    struct TileReveal {
+        uint256 x;
+        uint256 y;
+        bytes32 tileData;
+        bytes32[] proof;
+    }
+
+    /**
+     * @notice Move the character one tile in the specified direction.
+     *         Verifies any supplied tile proofs and emits relevant events.
+     */
+    function moveCharacter(Direction dir, TileReveal[] calldata reveals) external {
+        Position memory newPos = characterPosition;
+
+        if (dir == Direction.Left) {
+            if (newPos.x > 0) newPos.x -= 1;
+        } else if (dir == Direction.Right) {
+            newPos.x += 1;
+        } else if (dir == Direction.Up) {
+            if (newPos.y > 0) newPos.y -= 1;
+        } else if (dir == Direction.Down) {
+            newPos.y += 1;
+        }
+
+        uint256 collided = _checkCollision(newPos);
+        if (collided != type(uint256).max) {
+            characterPosition = Position(0, 0);
+            emit CollisionDetected(collided);
+        } else {
+            characterPosition = newPos;
+        }
+
+        for (uint256 i; i < reveals.length; i++) {
+            if (_verifyTile(reveals[i])) {
+                bytes32 key = _tileKey(reveals[i].x, reveals[i].y);
+                if (!revealedTiles[key]) {
+                    revealedTiles[key] = true;
+                    emit TileRevealed(reveals[i].x, reveals[i].y);
+                }
+            }
+        }
+
+        emit CharacterMoved(characterPosition.x, characterPosition.y);
+    }
+
+    /**
+     * @notice Simple collision check against stored obstacles.
+     * @return obstacleId ID that was hit or max uint if none.
+     */
+    function _checkCollision(Position memory pos) internal view returns (uint256 obstacleId) {
+        for (uint256 i = 0; i < 256; i++) {
+            if (obstacles[i].pos.x == pos.x && obstacles[i].pos.y == pos.y) {
+                return i;
+            }
+        }
+        return type(uint256).max;
+    }
+
+    function _verifyTile(TileReveal memory reveal) internal view returns (bool) {
+        bytes32 leaf = keccak256(abi.encodePacked(reveal.x, reveal.y, reveal.tileData));
+        return MerkleProof.verify(reveal.proof, worldRoot, leaf);
+    }
+
+    function _tileKey(uint256 x, uint256 y) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(x, y));
+    }
+}
+

--- a/contracts/HitboxNFT.sol
+++ b/contracts/HitboxNFT.sol
@@ -1,1 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/utils/Base64.sol";
+
+interface IHitboxGame {
+    function characterPosition() external view returns (uint256, uint256);
+}
+
+/**
+ * @title HitboxNFT
+ * @notice Simple ERC721 token that renders a 32x32 SVG view of the game.
+ */
+contract HitboxNFT is ERC721 {
+    IHitboxGame public immutable game;
+    uint256 public nextId;
+
+    constructor(address gameAddress) ERC721("Hitbox", "HBOX") {
+        game = IHitboxGame(gameAddress);
+    }
+
+    function mint() external {
+        _mint(msg.sender, nextId);
+        nextId++;
+    }
+
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        require(_exists(tokenId), "nonexistent token");
+        (uint256 x, uint256 y) = game.characterPosition();
+        string memory svg = _buildSvg(x, y);
+        string memory image = string.concat("data:image/svg+xml;base64,", Base64.encode(bytes(svg)));
+        string memory json = string.concat('{"name":"Hitbox","description":"On-chain game","image":"', image, '"}');
+        return string.concat("data:application/json;base64,", Base64.encode(bytes(json)));
+    }
+    function _buildSvg(uint256 x, uint256 y) internal pure returns (string memory) {
+        string memory rect = string(abi.encodePacked("<rect fill='red' x='", _toString(x % 32), "' y='", _toString(y % 32), "' width='1' height='1'/>"));
+        return string(abi.encodePacked(
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'>",
+            "<rect width='32' height='32' fill='black'/>",
+            rect,
+            "</svg>"
+        ));
+    }
+
+
+    function _toString(uint256 value) internal pure returns (string memory) {
+        if (value == 0) {
+            return "0";
+        }
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        return string(buffer);
+    }
+}
 


### PR DESCRIPTION
## Summary
- flesh out `HitboxGame` with state and movement logic
- implement a simple ERC721 `HitboxNFT` that renders an SVG based on the game's position

## Testing
- `npx hardhat test` *(fails: 403 Forbidden)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68407f2e1c74832c91821d1306e301a3